### PR TITLE
end buffer stream if 'fas' stream ends before emitting

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -21,8 +21,8 @@ emitUpdate = (emitter) ->
 emitDelete = (emitter) ->
   R.compose(emitter.emit.bind(emitter), Crud.Delete)
 
-# :: ([x] -> f x) ->
-#    (x -> f x) ->
+# :: ([Crud a] -> f (Crud a)) ->
+#    (Crud a -> f (Crud a)) ->
 #    ((x -> y) -> f x -> f y) ->
 #    f a ->
 #    (f a -> f (Crud a) -> f a) ->
@@ -36,10 +36,10 @@ emitDelete = (emitter) ->
 #
 applyToFirst = R.curry (fromArray, point, map, empty, f, fas, cruds) ->
   firstFa  = fas.take(1).map(map(Crud.Create))
-  buffered = cruds.bufferBy(firstFa).take(1).map(fromArray)
+  buffered = cruds.bufferBy(firstFa, flushOnEnd: false).take(1).map(fromArray)
   skipped  = cruds.skipUntilBy(firstFa).map(point)
 
-  K.merge([firstFa, buffered, skipped]).scan(f, empty)
+  K.merge([firstFa, buffered, skipped]).scan(f, empty).changes()
 
 # :: ([a] -> Crud a -> [a]) -> Kefir e [a] -> Kefir e (Crud a) -> Kefir e [a]
 arrayApplyToFirst = R.curry (f, as, cruds) ->

--- a/test/stream-spec.coffee
+++ b/test/stream-spec.coffee
@@ -35,10 +35,10 @@ describe "applyToFirst", ->
 
     expect(last(applied).then(getOrElse([]))).to.become(expectedFinal)
 
-  it "should be the result of applying crud events to an empty array when bs never emits", ->
+  it "should end when bs ends before emitting", ->
     applied = applyToFirstA(K.never(), K.sequentially(50, cruds))
 
-    expect(last(applied).then(getOrElse([]))).to.become(R.drop(2, expectedFinal))
+    expect(last(applied).then(getOrElse("novalue"))).to.become("novalue")
 
   it "should be the first bs when crud stream never emits", ->
     applied = applyToFirstA(K.sequentially(50, bs), K.never())


### PR DESCRIPTION
This prevents the buffer stream from buffering all the crud events. (until crud stream ends)